### PR TITLE
feat: split CLI entry from library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "vscode-languageserver-protocol": "^3.17.5"
       },
       "bin": {
-        "docgram": "dist/index.js"
+        "docgram": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^24.3.0",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "description": "Generate diagrams from source code",
   "main": "dist/index.js",
   "bin": {
-    "docgram": "dist/index.js"
+    "docgram": "dist/cli.js"
   },
   "files": ["dist"],
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "diagram": "npm run build && node dist/index.js diagram",
-    "docs": "npm run build && node dist/index.js docs",
+    "diagram": "npm run build && node dist/cli.js diagram",
+    "docs": "npm run build && node dist/cli.js docs",
     "test": "npm run build && node --test",
     "prepublishOnly": "npm run build"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { writeFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+import { buildService } from './index.js';
+
+const program = new Command();
+
+program.name('docgram').description('Generate diagrams from source code');
+
+program
+  .command('diagram')
+  .argument('<path...>', 'File or directory to parse')
+  .option('--parser <parser>', 'Parser implementation to use (ts|lsp)', 'ts')
+  .action(async (paths: string[], opts) => {
+    const service = buildService(opts.parser);
+    const diagram = await service.generateFromPaths(paths);
+    console.log(diagram);
+  });
+
+program
+  .command('docs')
+  .argument('<path...>', 'File or directory to parse')
+  .option('--parser <parser>', 'Parser implementation to use (ts|lsp)', 'ts')
+  .action(async (paths: string[], opts) => {
+    const service = buildService(opts.parser);
+    const diagram = await service.generateFromPaths(paths);
+    const target = paths[0];
+    const dir = statSync(target).isDirectory() ? target : path.dirname(target);
+    const title = path.basename(dir);
+    const content = `# ${title}\n\n\`\`\`mermaid\n${diagram}\n\`\`\`\n`;
+    const readmePath = path.join(dir, 'README.md');
+    writeFileSync(readmePath, content);
+    console.log(`README written to ${readmePath}`);
+  });
+
+program.parse();
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,8 @@
-#!/usr/bin/env node
-import { Command } from 'commander';
-import { writeFileSync, statSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { DiagramService } from './core/usecases/generateDiagram.js';
 import { TypeScriptParser } from './infrastructure/parsers/typescriptParser.js';
 import { MermaidDiagramGenerator } from './infrastructure/diagram/mermaidGenerator.js';
 import { LspParser } from './infrastructure/parsers/lspParser.js';
 import { StdioLanguageClient } from './infrastructure/lsp/stdioClient.js';
-
-const program = new Command();
-
-program.name('docgram').description('Generate diagrams from source code');
 
 export function buildService(parserOption: string) {
   const generator = new MermaidDiagramGenerator();
@@ -25,36 +16,6 @@ export function buildService(parserOption: string) {
   return new DiagramService(parser, generator);
 }
 
-program
-  .command('diagram')
-  .argument('<path...>', 'File or directory to parse')
-  .option('--parser <parser>', 'Parser implementation to use (ts|lsp)', 'ts')
-  .action(async (paths: string[], opts) => {
-    const service = buildService(opts.parser);
-    const diagram = await service.generateFromPaths(paths);
-    console.log(diagram);
-  });
-
-program
-  .command('docs')
-  .argument('<path...>', 'File or directory to parse')
-  .option('--parser <parser>', 'Parser implementation to use (ts|lsp)', 'ts')
-  .action(async (paths: string[], opts) => {
-    const service = buildService(opts.parser);
-    const diagram = await service.generateFromPaths(paths);
-    const target = paths[0];
-    const dir = statSync(target).isDirectory() ? target : path.dirname(target);
-    const title = path.basename(dir);
-    const content = `# ${title}\n\n\`\`\`mermaid\n${diagram}\n\`\`\`\n`;
-    const readmePath = path.join(dir, 'README.md');
-    writeFileSync(readmePath, content);
-    console.log(`README written to ${readmePath}`);
-  });
-
-if (fileURLToPath(import.meta.url) === process.argv[1]) {
-  program.parse();
-}
-
 export {
   DiagramService,
   TypeScriptParser,
@@ -62,3 +23,4 @@ export {
   LspParser,
   StdioLanguageClient,
 };
+


### PR DESCRIPTION
## Summary
- move CLI code into a dedicated `cli.ts`
- keep library exports in `index.ts`
- update scripts and tests to use the new CLI entry point
- always parse CLI commands without runtime path check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b59263a2a88321b1cdcbb9bc61ab93