### PR TITLE
Handle destructured method parameters

### DIFF
--- a/fixtures/destruct.ts
+++ b/fixtures/destruct.ts
@@ -10,4 +10,9 @@ export class Config {
     this.foo = foo;
     this.bar = bar;
   }
+
+  update({ foo, bar }: Options): void {
+    this.foo = foo;
+    this.bar = bar;
+  }
 }

--- a/fixtures/destructUntyped.ts
+++ b/fixtures/destructUntyped.ts
@@ -5,4 +5,9 @@ export class ConfigUntyped {
     this.foo = foo;
     this.bar = bar;
   }
+
+  update({ foo, bar }): void {
+    this.foo = foo;
+    this.bar = bar;
+  }
 }

--- a/src/infrastructure/parsers/typescriptParser.ts
+++ b/src/infrastructure/parsers/typescriptParser.ts
@@ -91,21 +91,18 @@ export class TypeScriptParser implements Parser {
 
   private classMethods(c: ClassDeclaration, entity: EntityInfo): void {
     c.getMethods().forEach(m => {
-      const parameters = m.getParameters().map(prm => ({
-        name: prm.getName(),
-        type: this.formatType(prm.getType()),
-      }));
+      const params = m.getParameters().map(prm => this.paramEntry(prm));
       entity.members.push({
         name: m.getName(),
         kind: 'method',
         visibility: m.getScope() ?? 'public',
         returnType: this.formatType(m.getReturnType()),
-        parameters,
+        parameters: params.map(p => p.info),
         isStatic: m.isStatic?.() ?? false,
         isAbstract: m.isAbstract?.() ?? false,
         typeParameters: m.getTypeParameters().map(tp => tp.getText()),
       });
-      m.getParameters().forEach(prm => this.addParamRelation(entity, prm.getType(), prm.getName()));
+      params.forEach(p => this.addParamRelation(entity, p.type, p.info.name));
       this.addReturnRelation(entity, m.getReturnType());
     });
   }
@@ -166,19 +163,17 @@ export class TypeScriptParser implements Parser {
 
   private interfaceMethods(i: InterfaceDeclaration, entity: EntityInfo): void {
     i.getMethods().forEach(m => {
-      const parameters: ParameterInfo[] = m
-        .getParameters()
-        .map(prm => ({ name: prm.getName(), type: this.formatType(prm.getType()) }));
+      const params = m.getParameters().map(prm => this.paramEntry(prm));
       entity.members.push({
         name: m.getName(),
         kind: 'method',
         visibility: 'public',
         returnType: this.formatType(m.getReturnType()),
-        parameters,
+        parameters: params.map(p => p.info),
         isAbstract: true,
         typeParameters: m.getTypeParameters().map(tp => tp.getText()),
       });
-      m.getParameters().forEach(prm => this.addParamRelation(entity, prm.getType(), prm.getName()));
+      params.forEach(p => this.addParamRelation(entity, p.type, p.info.name));
       this.addReturnRelation(entity, m.getReturnType());
     });
   }

--- a/test/diagram.test.ts
+++ b/test/diagram.test.ts
@@ -58,6 +58,22 @@ test('diagram falls back to object for untyped destructured constructors', async
   expect(diagram.includes('+ConfigUntyped(foo:')).toBe(false);
 });
 
+test('diagram omits parameter destructuring in methods', async () => {
+  expect.hasAssertions();
+  const service = new DiagramService(new TypeScriptParser(), new MermaidDiagramGenerator());
+  const diagram = await service.generateFromPaths([destruct]);
+  expect(diagram).toContain('+update(options: Options): void');
+  expect(diagram.includes('+update(foo:')).toBe(false);
+});
+
+test('diagram falls back to object for untyped destructured methods', async () => {
+  expect.hasAssertions();
+  const service = new DiagramService(new TypeScriptParser(), new MermaidDiagramGenerator());
+  const diagram = await service.generateFromPaths([destructUntyped]);
+  expect(diagram).toContain('+update(options: object): void');
+  expect(diagram.includes('+update(foo:')).toBe(false);
+});
+
 test('docs command writes README with diagram', () => {
   expect.hasAssertions();
   const dir = path.join('fixtures');

--- a/test/lspParser.test.ts
+++ b/test/lspParser.test.ts
@@ -129,3 +129,25 @@ test('LSP parser falls back to object for untyped destructuring in constructors'
   expect(ctor?.parameters).toEqual([{ name: 'options', type: 'object' }]);
 });
 
+test('LSP parser handles object destructuring in methods', async () => {
+  expect.hasAssertions();
+  const client = new StdioLanguageClient(path.join('node_modules', '.bin', 'typescript-language-server'), ['--stdio']);
+  const parser = new LspParser(client);
+  const entities = await parser.parse(['fixtures/destruct.ts']);
+  const config = entities.find(e => e.name === 'Config');
+  expect(config).toBeDefined();
+  const method = config?.members.find(m => m.kind === 'method' && m.name === 'update');
+  expect(method?.parameters).toEqual([{ name: 'options', type: 'Options' }]);
+});
+
+test('LSP parser falls back to object for untyped destructured methods', async () => {
+  expect.hasAssertions();
+  const client = new StdioLanguageClient(path.join('node_modules', '.bin', 'typescript-language-server'), ['--stdio']);
+  const parser = new LspParser(client);
+  const entities = await parser.parse(['fixtures/destructUntyped.ts']);
+  const config = entities.find(e => e.name === 'ConfigUntyped');
+  expect(config).toBeDefined();
+  const method = config?.members.find(m => m.kind === 'method' && m.name === 'update');
+  expect(method?.parameters).toEqual([{ name: 'options', type: 'object' }]);
+});
+

--- a/test/typescriptParser.test.ts
+++ b/test/typescriptParser.test.ts
@@ -21,3 +21,21 @@ test('TypeScript parser falls back to object for untyped destructuring', async (
   const ctor = config?.members.find(m => m.kind === 'constructor');
   expect(ctor?.parameters).toEqual([{ name: 'options', type: 'object' }]);
 });
+
+test('TypeScript parser handles object destructuring in methods', async () => {
+  expect.hasAssertions();
+  const parser = new TypeScriptParser();
+  const entities = await parser.parse(['fixtures/destruct.ts']);
+  const config = entities.find(e => e.name === 'Config');
+  const method = config?.members.find(m => m.kind === 'method' && m.name === 'update');
+  expect(method?.parameters).toEqual([{ name: 'options', type: 'Options' }]);
+});
+
+test('TypeScript parser falls back to object for untyped destructured methods', async () => {
+  expect.hasAssertions();
+  const parser = new TypeScriptParser();
+  const entities = await parser.parse(['fixtures/destructUntyped.ts']);
+  const config = entities.find(e => e.name === 'ConfigUntyped');
+  const method = config?.members.find(m => m.kind === 'method' && m.name === 'update');
+  expect(method?.parameters).toEqual([{ name: 'options', type: 'object' }]);
+});


### PR DESCRIPTION
## Summary
- treat object destructuring in method and interface parameters like constructors
- test parsers and diagram generator for typed and untyped destructured methods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8c9aa6c988321b538b7f5b9f9814e