### PR TITLE
fix: include readme in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": {
     "docgram": "dist/cli.js"
   },
-  "files": ["dist"],
+  "files": ["dist", "README.md"],
   "type": "module",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary
- include README in published files so the npm package displays documentation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8d45f1cd8832185e064552b4248a3