### PR TITLE
feat: add C# parser

### DIFF
--- a/fixtures/sample.cs
+++ b/fixtures/sample.cs
@@ -1,0 +1,5 @@
+public class Foo
+{
+    public int Bar;
+    public void Baz() {}
+}

--- a/fixtures/sample.cs
+++ b/fixtures/sample.cs
@@ -1,6 +1,10 @@
+public class Bar
+{
+}
+
 public class Foo
 {
-    public int Bar;
+    public Bar Bar { get; set; }
     public string Name { get; set; }
     public int Add(int x, int y) { return x + y; }
 }

--- a/fixtures/sample.cs
+++ b/fixtures/sample.cs
@@ -1,5 +1,6 @@
 public class Foo
 {
     public int Bar;
-    public void Baz() {}
+    public string Name { get; set; }
+    public int Add(int x, int y) { return x + y; }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ program.name('docgram').description('Generate diagrams from source code');
 program
   .command('diagram')
   .argument('<path...>', 'File or directory to parse')
-  .option('--parser <parser>', 'Parser implementation to use (ts|lsp)', 'ts')
+  .option('--parser <parser>', 'Parser implementation to use (ts|lsp|csharp)', 'ts')
   .action(async (paths: string[], opts) => {
     try {
       const service = buildService(opts.parser);
@@ -26,7 +26,7 @@ program
 program
   .command('docs')
   .argument('<path...>', 'File or directory to parse')
-  .option('--parser <parser>', 'Parser implementation to use (ts|lsp)', 'ts')
+  .option('--parser <parser>', 'Parser implementation to use (ts|lsp|csharp)', 'ts')
   .action(async (paths: string[], opts) => {
     try {
       const service = buildService(opts.parser);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { TypeScriptParser } from './infrastructure/parsers/typescriptParser.js';
 import { MermaidDiagramGenerator } from './infrastructure/diagram/mermaidGenerator.js';
 import { LspParser } from './infrastructure/parsers/lspParser.js';
 import { StdioLanguageClient } from './infrastructure/lsp/stdioClient.js';
+import { CSharpParser } from './infrastructure/parsers/csharpParser.js';
 
 export function buildService(parserOption: string) {
   const generator = new MermaidDiagramGenerator();
@@ -10,6 +11,8 @@ export function buildService(parserOption: string) {
   if (parserOption === 'lsp') {
     const client = new StdioLanguageClient('typescript-language-server', ['--stdio']);
     parser = new LspParser(client);
+  } else if (parserOption === 'csharp') {
+    parser = new CSharpParser();
   } else {
     parser = new TypeScriptParser();
   }
@@ -22,5 +25,6 @@ export {
   MermaidDiagramGenerator,
   LspParser,
   StdioLanguageClient,
+  CSharpParser,
 };
 

--- a/src/infrastructure/parsers/csharpParser.ts
+++ b/src/infrastructure/parsers/csharpParser.ts
@@ -1,0 +1,16 @@
+import { Parser, EntityInfo, LanguageClient } from '../../core/model.js';
+import { LspParser } from './lspParser.js';
+import { StdioLanguageClient } from '../lsp/stdioClient.js';
+
+export class CSharpParser implements Parser {
+  private parser: LspParser;
+
+  constructor(client?: LanguageClient) {
+    const lspClient = client ?? new StdioLanguageClient('csharp-ls', ['--stdio']);
+    this.parser = new LspParser(lspClient, '.cs');
+  }
+
+  parse(paths: string[]): Promise<EntityInfo[]> {
+    return this.parser.parse(paths);
+  }
+}

--- a/src/infrastructure/parsers/lspParser.ts
+++ b/src/infrastructure/parsers/lspParser.ts
@@ -361,7 +361,9 @@ export class LspParser implements Parser {
     }
     const paramMatch = part.match(/([A-Za-z0-9_]+)\s*:\s*([^,]+)/);
     if (paramMatch) return { name: paramMatch[1], type: paramMatch[2].trim() };
-    return { name: part, type: 'any' };
+    const csMatch = part.match(/([^\s]+)\s+([A-Za-z0-9_]+)(?:\s*=\s*[^,]+)?/);
+    if (csMatch) return { name: csMatch[2], type: csMatch[1] };
+    return { name: part.trim(), type: 'any' };
   }
 
   private parseReturn(line: string): string | undefined {

--- a/test/csharpParser.test.ts
+++ b/test/csharpParser.test.ts
@@ -10,7 +10,7 @@ class FakeClient implements LanguageClient {
       {
         name: 'Foo',
         kind: SymbolKind.Class,
-        range: { start: { line: 0, character: 0 }, end: { line: 4, character: 0 } },
+        range: { start: { line: 0, character: 0 }, end: { line: 5, character: 0 } },
         selectionRange: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
         children: [
           {
@@ -20,10 +20,16 @@ class FakeClient implements LanguageClient {
             selectionRange: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } },
           },
           {
-            name: 'Baz',
-            kind: SymbolKind.Method,
+            name: 'Name',
+            kind: SymbolKind.Property,
             range: { start: { line: 3, character: 0 }, end: { line: 3, character: 0 } },
             selectionRange: { start: { line: 3, character: 0 }, end: { line: 3, character: 0 } },
+          },
+          {
+            name: 'Add',
+            kind: SymbolKind.Method,
+            range: { start: { line: 4, character: 0 }, end: { line: 4, character: 0 } },
+            selectionRange: { start: { line: 4, character: 0 }, end: { line: 4, character: 0 } },
           },
         ],
       },
@@ -39,9 +45,16 @@ test('C# parser builds entities from document symbols', async () => {
   expect(entities).toHaveLength(1);
   const foo = entities[0];
   expect(foo.name).toBe('Foo');
-  expect(foo.members).toHaveLength(2);
+  expect(foo.members).toHaveLength(3);
   expect(foo.members.some(m => m.name === 'Bar' && m.type === 'int')).toBe(true);
-  expect(foo.members.some(m => m.name === 'Baz' && m.returnType === 'void')).toBe(true);
+  expect(foo.members.some(m => m.name === 'Name' && m.type === 'string')).toBe(true);
+  const add = foo.members.find(m => m.name === 'Add');
+  expect(add).toBeDefined();
+  expect(add?.returnType).toBe('int');
+  expect(add?.parameters).toEqual([
+    { name: 'x', type: 'int' },
+    { name: 'y', type: 'int' },
+  ]);
   expect(foo.namespace).toBe('fixtures');
 });
 

--- a/test/csharpParser.test.ts
+++ b/test/csharpParser.test.ts
@@ -8,28 +8,34 @@ class FakeClient implements LanguageClient {
   async documentSymbols(): Promise<DocumentSymbol[]> {
     return [
       {
+        name: 'Bar',
+        kind: SymbolKind.Class,
+        range: { start: { line: 0, character: 0 }, end: { line: 2, character: 0 } },
+        selectionRange: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+      },
+      {
         name: 'Foo',
         kind: SymbolKind.Class,
-        range: { start: { line: 0, character: 0 }, end: { line: 5, character: 0 } },
-        selectionRange: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        range: { start: { line: 4, character: 0 }, end: { line: 9, character: 0 } },
+        selectionRange: { start: { line: 4, character: 0 }, end: { line: 4, character: 0 } },
         children: [
           {
             name: 'Bar',
-            kind: SymbolKind.Field,
-            range: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } },
-            selectionRange: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } },
+            kind: SymbolKind.Property,
+            range: { start: { line: 6, character: 0 }, end: { line: 6, character: 0 } },
+            selectionRange: { start: { line: 6, character: 0 }, end: { line: 6, character: 0 } },
           },
           {
             name: 'Name',
             kind: SymbolKind.Property,
-            range: { start: { line: 3, character: 0 }, end: { line: 3, character: 0 } },
-            selectionRange: { start: { line: 3, character: 0 }, end: { line: 3, character: 0 } },
+            range: { start: { line: 7, character: 0 }, end: { line: 7, character: 0 } },
+            selectionRange: { start: { line: 7, character: 0 }, end: { line: 7, character: 0 } },
           },
           {
             name: 'Add',
             kind: SymbolKind.Method,
-            range: { start: { line: 4, character: 0 }, end: { line: 4, character: 0 } },
-            selectionRange: { start: { line: 4, character: 0 }, end: { line: 4, character: 0 } },
+            range: { start: { line: 8, character: 0 }, end: { line: 8, character: 0 } },
+            selectionRange: { start: { line: 8, character: 0 }, end: { line: 8, character: 0 } },
           },
         ],
       },
@@ -42,11 +48,10 @@ test('C# parser builds entities from document symbols', async () => {
   expect.hasAssertions();
   const parser = new CSharpParser(new FakeClient());
   const entities = await parser.parse(['fixtures/sample.cs']);
-  expect(entities).toHaveLength(1);
-  const foo = entities[0];
-  expect(foo.name).toBe('Foo');
+  expect(entities).toHaveLength(2);
+  const foo = entities.find(e => e.name === 'Foo')!;
   expect(foo.members).toHaveLength(3);
-  expect(foo.members.some(m => m.name === 'Bar' && m.type === 'int')).toBe(true);
+  expect(foo.members.some(m => m.name === 'Bar' && m.type === 'Bar')).toBe(true);
   expect(foo.members.some(m => m.name === 'Name' && m.type === 'string')).toBe(true);
   const add = foo.members.find(m => m.name === 'Add');
   expect(add).toBeDefined();
@@ -56,12 +61,13 @@ test('C# parser builds entities from document symbols', async () => {
     { name: 'y', type: 'int' },
   ]);
   expect(foo.namespace).toBe('fixtures');
+  expect(foo.relations.some(r => r.type === 'composition' && r.target === 'Bar')).toBe(true);
 });
 
 test('C# parser collects files from directories', async () => {
   expect.hasAssertions();
   const parser = new CSharpParser(new FakeClient());
   const entities = await parser.parse(['fixtures']);
-  expect(entities).toHaveLength(1);
-  expect(entities[0].name).toBe('Foo');
+  expect(entities).toHaveLength(2);
+  expect(entities.map(e => e.name).sort()).toEqual(['Bar', 'Foo']);
 });


### PR DESCRIPTION
## Summary
- add configurable extension and C# syntax support to LSP parser
- introduce CSharpParser wired through CLI and index
- add fixture and tests for parsing C# files

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c56204163083219511f37365e1c2aa